### PR TITLE
refactor(NFeUtilities): `simplify using instruction and implement xmlWriter memory dispose`

### DIFF
--- a/src/Core/EficazFramework.SPED/Utilities/NFe/Utilities.cs
+++ b/src/Core/EficazFramework.SPED/Utilities/NFe/Utilities.cs
@@ -36,17 +36,19 @@ public class DownloadNF
         try
         {
             var xml = NFeToXmlDocument(instance);
-            var ms = new MemoryStream();
-            var xmlWriter = XmlWriter.Create(ms, new XmlWriterSettings() { Indent = false, NewLineChars = string.Empty, Encoding = encoder });
-            xml.Save(xmlWriter);
-            var reader = new StreamReader(ms, encoder, true);
-            ms.Seek(0L, SeekOrigin.Begin);
-            string res = reader.ReadToEnd();
-            ms.Close();
-            ms.Dispose();
-            reader.Close();
-            reader.Dispose();
-            return res;
+            using (var ms = new MemoryStream())
+            {
+                using (var xmlWriter = XmlWriter.Create(ms, new XmlWriterSettings() { Indent = false, NewLineChars = string.Empty, Encoding = encoder }))
+                {
+                    xml.Save(xmlWriter);
+                    using (var reader = new StreamReader(ms, encoder, true))
+                    {
+                        ms.Seek(0L, SeekOrigin.Begin);
+                        string res = reader.ReadToEnd();
+                        return res;
+                    }
+                }
+            }
         }
         // Return stringWriter.ToString
         catch (Exception)


### PR DESCRIPTION
Mudanças realizadas:

- Implementação da instrução `using` para simplificar o uso do método `Close()` e `Dispose()`;
- Implementação da instrução `using` para a classe xmlWriter, como forma de liberar recursos não gerenciados.