### PR TITLE
Troca de dependência FluentAssertions por AwesomeAssertions por motivos de licenciamento de uso.

### DIFF
--- a/src/Tests/EficazFramework.Tests/EficazFramework.Tests.csproj
+++ b/src/Tests/EficazFramework.Tests/EficazFramework.Tests.csproj
@@ -2,19 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
-
     <Version>6.3.2</Version>
-
     <Description>Biblioteca de testes da Eficaz Framework Core.</Description>
-
     <RootNamespace>EficazFramework</RootNamespace>
-
     <SignAssembly>True</SignAssembly>
-
     <AssemblyOriginatorKeyFile>EfCore.snk</AssemblyOriginatorKeyFile>
-
     <UserSecretsId>9df2e9d9-6b22-460c-afa9-22b7fc35a9a5</UserSecretsId>
   </PropertyGroup>
 
@@ -25,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AwesomeAssertions" Version="8.0.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -33,7 +27,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />


### PR DESCRIPTION
Troca de dependência FluentAssertions por AwesomeAssertions por motivos de licenciamento de uso.