### PR TITLE
Atualização de dependências para runtime 9.0.9 e resolução de breaking changes

### DIFF
--- a/src/Core/EficazFramework.SPED.Abstractions/EficazFramework.SPED.Abstractions.csproj
+++ b/src/Core/EficazFramework.SPED.Abstractions/EficazFramework.SPED.Abstractions.csproj
@@ -32,8 +32,15 @@
 
 	<ItemGroup>
 		<PackageReference Include="System.ServiceModel.Security" Version="6.0.0" />
-		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.2" />
-		<PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
 	</ItemGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.9" />
+		<PackageReference Include="System.Formats.Asn1" Version="9.0.9" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+		<PackageReference Include="System.Formats.Asn1" Version="8.0.2" />
+	</ItemGroup>
 </Project>

--- a/src/Core/EficazFramework.SPED/EficazFramework.SPED.csproj
+++ b/src/Core/EficazFramework.SPED/EficazFramework.SPED.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DefaultDocumentation" Version="0.8.2">
+    <PackageReference Include="DefaultDocumentation" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -65,15 +65,15 @@
   </ItemGroup>
 	
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
-    <PackageReference Include="System.ServiceModel.Http" Version="8.1.1" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="8.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+    <PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="8.1.2" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
 	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-	  <PackageReference Include="System.ServiceModel.Http" Version="8.1.1" />
-	  <PackageReference Include="System.ServiceModel.NetTcp" Version="8.1.1" />
+	  <PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
+	  <PackageReference Include="System.ServiceModel.NetTcp" Version="8.1.2" />
   </ItemGroup>
   
 	<ItemGroup>

--- a/src/Tests/EficazFramework.Tests/EficazFramework.Tests.csproj
+++ b/src/Tests/EficazFramework.Tests/EficazFramework.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="8.0.1" />
+    <PackageReference Include="AwesomeAssertions" Version="9.1.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -27,13 +27,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0-preview-25107-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageReference Include="SolutionScripts" Version="1.2.0" />
   </ItemGroup>
 

--- a/src/Tests/EficazFramework.Tests/Extensions/Number.cs
+++ b/src/Tests/EficazFramework.Tests/Extensions/Number.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Extensions;

--- a/src/Tests/EficazFramework.Tests/Extensions/Text.cs
+++ b/src/Tests/EficazFramework.Tests/Extensions/Text.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Extensions;

--- a/src/Tests/EficazFramework.Tests/Schemas/ECF/Bloco0/Registro0020.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/ECF/Bloco0/Registro0020.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.ECF.Bloco0;

--- a/src/Tests/EficazFramework.Tests/Schemas/ECF/Bloco0/Registro0021.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/ECF/Bloco0/Registro0021.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.ECF.Bloco0;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco C/RegistroC500.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco C/RegistroC500.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_Contribuicoes.BlocoC;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco C/RegistroC501.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco C/RegistroC501.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_Contribuicoes.BlocoC;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco C/RegistroC505.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco C/RegistroC505.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_Contribuicoes.BlocoC;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco D/RegistroD500.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco D/RegistroD500.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_Contribuicoes.BlocoD;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco D/RegistroD501.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco D/RegistroD501.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_Contribuicoes.BlocoD;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco D/RegistroD505.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco D/RegistroD505.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_Contribuicoes.BlocoD;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco F/RegistroF100.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco F/RegistroF100.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_Contribuicoes.BlocoF;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco F/RegistroF600.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD Contribuições/Bloco F/RegistroF600.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_Contribuicoes.BlocoF;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/Base/IO.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/Base/IO.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using System.Linq;
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace EficazFramework.SPED.Schemas.EFD_ICMS_IPI.BaseTests;
 

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/Bloco0/Registro0000.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/Bloco0/Registro0000.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_ICMS_IPI.Bloco0;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/Bloco0/Registro0002.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/Bloco0/Registro0002.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_ICMS_IPI.Bloco0;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/Bloco0/Registro0220.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/Bloco0/Registro0220.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_ICMS_IPI.Bloco0;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/Bloco1/Registro1601.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/Bloco1/Registro1601.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_ICMS_IPI.Bloco1;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoC/RegistroC500.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoC/RegistroC500.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_ICMS_IPI.BlocoC;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoD/RegistroD510.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoD/RegistroD510.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_ICMS_IPI.BlocoD;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoE/RegistroE500.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoE/RegistroE500.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_ICMS_IPI.BlocoE;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoE/RegistroE510.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoE/RegistroE510.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_ICMS_IPI.BlocoE;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoE/RegistroE520.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoE/RegistroE520.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_ICMS_IPI.BlocoE;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoE/RegistroE530.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoE/RegistroE530.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_ICMS_IPI.BlocoE;

--- a/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoE/RegistroE531.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/EFD ICMS IPI/BlocoE/RegistroE531.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.EFD_ICMS_IPI.BlocoE;

--- a/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Base/IO.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Base/IO.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using System.Linq;
-using FluentAssertions;
+using AwesomeAssertions;
 
 namespace EficazFramework.SPED.Schemas.LCDPR.BaseTests;
 

--- a/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Bloco0/Registro0000.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Bloco0/Registro0000.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.LCDPR.Bloco0;

--- a/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Bloco0/Registro0010.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Bloco0/Registro0010.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.LCDPR.Bloco0;

--- a/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Bloco0/Registro0030.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Bloco0/Registro0030.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.LCDPR.Bloco0;

--- a/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Bloco0/Registro0040.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Bloco0/Registro0040.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.LCDPR.Bloco0;

--- a/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Bloco0/Registro0045.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Bloco0/Registro0045.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.LCDPR.Bloco0;

--- a/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Bloco0/Registro0050.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/LCDPR/Bloco0/Registro0050.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.LCDPR.Bloco0;

--- a/src/Tests/EficazFramework.Tests/Schemas/LCDPR/BlocoQ/RegistroQ100.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/LCDPR/BlocoQ/RegistroQ100.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.LCDPR.BlocoQ;

--- a/src/Tests/EficazFramework.Tests/Schemas/LCDPR/BlocoQ/RegistroQ200.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/LCDPR/BlocoQ/RegistroQ200.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 using NUnit.Framework;
 
 namespace EficazFramework.SPED.Schemas.LCDPR.BlocoQ;

--- a/src/Tests/EficazFramework.Tests/Services/NFe/Autorizacao.cs
+++ b/src/Tests/EficazFramework.Tests/Services/NFe/Autorizacao.cs
@@ -20,7 +20,7 @@ public class AutorizacaoTests : BaseNFeTests
         result.Ambiente.Should().Be(Schemas.NFe.Ambiente.Homologacao);
         result.RetornoCodigo.Should().Be("104");
         result.ProtocoloRecebimento.Should().NotBeNull();
-        result.ProtocoloRecebimento.InformacoesProtocolo.StatusNFeCodigo.Should().Be("230"); //Emitente não cadastrado para emissão de NFe
+        result.ProtocoloRecebimento.InformacoesProtocolo.StatusNFeCodigo.Should().BeOneOf("230", "231"); //Emitente não cadastrado para emissão de NFe
     }
 
 

--- a/src/Tests/EficazFramework.Tests/usings.cs
+++ b/src/Tests/EficazFramework.Tests/usings.cs
@@ -1,4 +1,4 @@
-﻿global using FluentAssertions;
+﻿global using AwesomeAssertions;
 global using NUnit.Framework;
 global using System;
 global using System.IO;


### PR DESCRIPTION
#### PR Classification  
Atualização de dependências e refatoração de código para suporte a múltiplos frameworks e melhorias nos testes.  

#### PR Summary  
Este PR atualiza dependências para versões mais recentes, adiciona suporte a múltiplos frameworks-alvo (`net9.0` e `net8.0`), e substitui o pacote `FluentAssertions` pelo `AwesomeAssertions`. Ajustes foram feitos em testes para refletir essas mudanças.  
- **`EficazFramework.SPED.Abstractions.csproj`**: Adição de condições para frameworks-alvo e atualização de pacotes como `System.Security.Cryptography.Pkcs`.  
- **`EficazFramework.SPED.csproj`**: Atualização de pacotes como `DefaultDocumentation` e `Microsoft.Extensions.Logging.Abstractions`.  
- **`EficazFramework.Tests.csproj`**: Atualização de pacotes de teste e remoção de versões antigas.  
- **Substituição global**: Migração de `FluentAssertions` para `AwesomeAssertions` em arquivos como `Number.cs`, `Text.cs` e `Registro0020.cs`.  
- **`Autorizacao.cs`**: Ajuste na validação de status do protocolo para aceitar múltiplos códigos (`230` ou `231`).  
