### PR TITLE
Feature/sped social/s1260-s1298-s1299 schemas v13

### DIFF
--- a/src/Core/EficazFramework.SPED.Schemas/e-Social/BaseClasses.cs
+++ b/src/Core/EficazFramework.SPED.Schemas/e-Social/BaseClasses.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Reflection.Metadata;
 
 namespace EficazFramework.SPED.Schemas.eSocial;
@@ -62,7 +62,7 @@ public abstract class Evento : ESocialBindableObject, IXmlSignableDocument
             "evtTabLotacao" => typeof(S1020),
             "evtRemun" => typeof(S1200),
             "evtComProd" => typeof(S1260),
-            "evtReabreEvPerv" => typeof(S1298),
+            "evtReabreEvPer" => typeof(S1298),
             "evtFechaEvPer" => typeof(S1299),
             "evtAdmissao" => typeof(S2200),
             _ => default

--- a/src/Core/EficazFramework.SPED.Schemas/e-Social/S-1299.cs
+++ b/src/Core/EficazFramework.SPED.Schemas/e-Social/S-1299.cs
@@ -1,4 +1,4 @@
-﻿namespace EficazFramework.SPED.Schemas.eSocial;
+namespace EficazFramework.SPED.Schemas.eSocial;
 
 [Serializable()]
 public partial class S1299 : Evento
@@ -95,6 +95,7 @@ public partial class S1299EvPer : ESocialBindableObject
         }
     }
 
+    [XmlElement("infoFechamento")]
     public S1299InfoFechamento infoFech
     {
         get => infoFechField;
@@ -242,7 +243,7 @@ public partial class S1299InfoFechamento : ESocialBindableObject
     private SimNaoString evtPgtosField = SimNaoString.Nao;
 
     [Obsolete("Descontinuado na versão S-1.02")]
-    private SimNaoString evtAqProdField = SimNaoString.Nao;
+    private SimNaoString? evtAqProdField;
 
     private SimNaoString evtComProdField = SimNaoString.Nao;
     private SimNaoString evtContratAvNPField = SimNaoString.Nao;
@@ -276,7 +277,7 @@ public partial class S1299InfoFechamento : ESocialBindableObject
     }
 
     [Obsolete("Descontinuado na versão S-1.02")]
-    public SimNaoString evtAqProd
+    public SimNaoString? evtAqProd
     {
         get => evtAqProdField;
         set

--- a/src/Tests/EficazFramework.Tests/Schemas/e-Social/BaseESocialTest.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/e-Social/BaseESocialTest.cs
@@ -1,4 +1,4 @@
-﻿namespace EficazFramework.SPED.Schemas.eSocial;
+namespace EficazFramework.SPED.Schemas.eSocial;
 
 public abstract class BaseESocialTest<T> : Tests.BaseTest where T : Evento
 {
@@ -90,13 +90,16 @@ public abstract class BaseESocialTest<T> : Tests.BaseTest where T : Evento
         Utilities.XML.Sign.SignXml(doc, EficazFramework.SPED.Schemas.eSocial.Evento.root, evento.TagToSign, cert, evento.SignAsSHA256, evento.EmptyURI);
 
         // adicionando os schemas para validação do documento XML
-        ValidationEventHandler eventHandler = new(ValidationEventHandler);
-        doc.Schemas.Add(ValidationSchemaNamespace, XmlReader.Create(new StringReader(ValidationSchema)));
-        doc.Schemas.Add(ValidationSchemaNamespace, XmlReader.Create(new StringReader(Resources.Schemas.eSocial.tipos)));
-        doc.Schemas.Add("http://www.w3.org/2000/09/xmldsig#", XmlReader.Create(new StringReader(Resources.Schemas.XML.Sign)));
-        // executando a validação
-        doc.Validate(eventHandler);
-        _errorCount.Should().Be(0);
+        if (!string.IsNullOrEmpty(ValidationSchema))
+        {
+            ValidationEventHandler eventHandler = new(ValidationEventHandler);
+            doc.Schemas.Add(ValidationSchemaNamespace, XmlReader.Create(new StringReader(ValidationSchema)));
+            doc.Schemas.Add(ValidationSchemaNamespace, XmlReader.Create(new StringReader(Resources.Schemas.eSocial.tipos)));
+            doc.Schemas.Add("http://www.w3.org/2000/09/xmldsig#", XmlReader.Create(new StringReader(Resources.Schemas.XML.Sign)));
+            // executando a validação
+            doc.Validate(eventHandler);
+            _errorCount.Should().Be(0);
+        }
     }
 
     private void ValidationEventHandler(object sender, ValidationEventArgs e)

--- a/src/Tests/EficazFramework.Tests/Schemas/e-Social/S-1260.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/e-Social/S-1260.cs
@@ -1,0 +1,251 @@
+namespace EficazFramework.SPED.Schemas.eSocial;
+
+public class S1260Test : BaseESocialTest<S1260>
+{
+    [Test]
+    [TestCase(Versao.v_S_01_02_00)]
+    [TestCase(Versao.v_S_01_03_00)]
+    public async Task Valida(Versao versao)
+    {
+        _versao = versao;
+        ValidationSchemaNamespace = $"http://www.esocial.gov.br/schema/evt/evtComProd/{versao}";
+        await TestaEvento();
+    }
+
+    [Test]
+    public async Task ImportaXmlLegado()
+    {
+        string xmlLegado = $@"<eSocial xmlns=""http://www.esocial.gov.br/schema/evt/evtComProd/v_S_01_01_00"">
+  <evtComProd Id=""ID1347855150001662025020112000000001"">
+    <ideEvento>
+      <indRetif>1</indRetif>
+      <indApuracao>1</indApuracao>
+      <perApur>2025-02</perApur>
+      <tpAmb>2</tpAmb>
+      <procEmi>1</procEmi>
+      <verProc>1.0</verProc>
+    </ideEvento>
+    <ideEmpregador>
+      <tpInsc>1</tpInsc>
+      <nrInsc>{CnpjCpf[..8]}</nrInsc>
+    </ideEmpregador>
+    <infoComProd>
+      <ideEstabel>
+        <nrInscEstabRural>12345678901234</nrInscEstabRural>
+        <tpComerc>
+          <indComerc>3</indComerc>
+          <vrTotCom>15000.50</vrTotCom>
+          <ideAdquir>
+            <tpInsc>1</tpInsc>
+            <nrInsc>98765432000199</nrInsc>
+            <vrComerc>15000.50</vrComerc>
+            <nfs>
+              <serie>1</serie>
+              <nrDocto>1001</nrDocto>
+              <dtEmisNF>2025-02-15</dtEmisNF>
+              <vlrBruto>15000.50</vlrBruto>
+              <vrCPDescPR>225.00</vrCPDescPR>
+              <vrRatDescPR>15.00</vrRatDescPR>
+              <vrSenarDesc>30.00</vrSenarDesc>
+            </nfs>
+          </ideAdquir>
+          <infoProcJud>
+            <tpProc>1</tpProc>
+            <nrProc>00012345620255010000</nrProc>
+            <codSusp>123456789</codSusp>
+            <vrCPSusp>100.00</vrCPSusp>
+            <vrRatSusp>10.00</vrRatSusp>
+            <vrSenarSusp>5.00</vrSenarSusp>
+          </infoProcJud>
+        </tpComerc>
+      </ideEstabel>
+    </infoComProd>
+  </evtComProd>
+</eSocial>";
+
+        var evento = (S1260)(await Evento.ReadAsync(xmlLegado));
+        evento.Should().NotBeNull();
+        evento.evtComProd.Should().NotBeNull();
+
+        // ideEvento
+        evento.evtComProd.ideEvento.perApur.Should().Be("2025-02");
+        evento.evtComProd.ideEvento.tpAmb.Should().Be(Ambiente.ProducaoRestrita_DadosReais);
+        evento.evtComProd.ideEvento.procEmi.Should().Be(EmissorEvento.AppEmpregador);
+
+        // ideEmpregador
+        evento.evtComProd.ideEmpregador.tpInsc.Should().Be(PersonalidadeJuridica.CNPJ);
+        evento.evtComProd.ideEmpregador.nrInsc.Should().Be(CnpjCpf[..8]);
+
+        // infoComProd
+        var estabel = evento.evtComProd.infoComProd.ideEstabel;
+        estabel.Should().NotBeNull();
+        estabel.nrInscEstabRural.Should().Be("12345678901234");
+        estabel.tpComerc.Should().HaveCount(1);
+
+        var tpCom = estabel.tpComerc.First();
+        tpCom.indComerc.Should().Be(IndicadorComercializacaoS1260.Vendas_a_PJ);
+        tpCom.vrTotCom.Should().Be(15000.50m);
+
+        // ideAdquir
+        tpCom.ideAdquir.Should().HaveCount(1);
+        var adquir = tpCom.ideAdquir.First();
+        adquir.tpInsc.Should().Be(PersonalidadeJuridica.CNPJ);
+        adquir.nrInsc.Should().Be("98765432000199");
+        adquir.vrComerc.Should().Be(15000.50m);
+
+        // nfs
+        adquir.nfs.Should().HaveCount(1);
+        var nf = adquir.nfs.First();
+        nf.serie.Should().Be("1");
+        nf.nrDocto.Should().Be("1001");
+        nf.dtEmisNF.Should().Be(new DateTime(2025, 2, 15));
+        nf.vlrBruto.Should().Be(15000.50m);
+        nf.vrCPDescPR.Should().Be(225.00m);
+        nf.vrRatDescPR.Should().Be(15.00m);
+        nf.vrSenarDesc.Should().Be(30.00m);
+
+        // infoProcJud
+        tpCom.infoProcJud.Should().HaveCount(1);
+        var procJud = tpCom.infoProcJud.First();
+        procJud.tpProc.Should().Be((sbyte)1);
+        procJud.nrProc.Should().Be("00012345620255010000");
+        procJud.codSusp.Should().Be("123456789");
+        procJud.vrCPSusp.Should().Be(100.00m);
+        procJud.vrRatSusp.Should().Be(10.00m);
+        procJud.vrSenarSusp.Should().Be(5.00m);
+    }
+
+    public override void PreencheCampos(S1260 evento)
+    {
+        evento.Versao = _versao;
+        evento.evtComProd = new S1260ComercializacaoProd
+        {
+            ideEvento = new IdeEventoPeriodico
+            {
+                indRetif = IndicadorRetificacao.Original,
+                indApuracao = IndicadorApuracao.Mensal,
+                perApur = "2025-02",
+                tpAmb = Ambiente.ProducaoRestrita_DadosReais,
+                procEmi = EmissorEvento.AppEmpregador,
+                verProc = "1.0"
+            },
+            ideEmpregador = new Empregador
+            {
+                tpInsc = PersonalidadeJuridica.CNPJ,
+                nrInsc = CnpjCpf[..8]
+            },
+            infoComProd = new S1260InfoComProducao
+            {
+                ideEstabel = new S1260IdeEstabelecimento
+                {
+                    nrInscEstabRural = "12345678901234",
+                    tpComerc =
+                    [
+                        new S1260TipoComercializacao
+                        {
+                            indComerc = IndicadorComercializacaoS1260.Vendas_a_PJ,
+                            vrTotCom = 25000.00m,
+                            ideAdquir =
+                            [
+                                new S1260TpComercIdeAdquirente
+                                {
+                                    tpInsc = PersonalidadeJuridica.CNPJ,
+                                    nrInsc = "98765432000199",
+                                    vrComerc = 25000.00m,
+                                    nfs =
+                                    [
+                                        new S1260IdeAdquirenteNf
+                                        {
+                                            serie = "1",
+                                            nrDocto = "2002",
+                                            dtEmisNF = new DateTime(2025, 2, 20),
+                                            vlrBruto = 25000.00m,
+                                            vrCPDescPR = 375.00m,
+                                            vrRatDescPR = 25.00m,
+                                            vrSenarDesc = 50.00m
+                                        }
+                                    ]
+                                }
+                            ],
+                            infoProcJud =
+                            [
+                                new S1260TipoComercializacaoInfoProcJudicial
+                                {
+                                    tpProc = 2,
+                                    nrProc = "50012345620255010000",
+                                    codSusp = "987654321",
+                                    vrCPSusp = 150.00m,
+                                    vrCPSuspSpecified = true,
+                                    vrRatSusp = 15.00m,
+                                    vrRatSuspSpecified = true,
+                                    vrSenarSusp = 8.00m,
+                                    vrSenarSuspSpecified = true
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        };
+    }
+
+    public override void ValidaInstanciasLeituraEscrita(S1260 instanciaPopulada, S1260 instanciaXml)
+    {
+        instanciaPopulada.Should().NotBeNull();
+        instanciaXml.Should().NotBeNull();
+
+        // ideEvento
+        instanciaXml.evtComProd.ideEvento.tpAmb.Should().Be(instanciaPopulada.evtComProd.ideEvento.tpAmb);
+        instanciaXml.evtComProd.ideEvento.procEmi.Should().Be(instanciaPopulada.evtComProd.ideEvento.procEmi);
+        instanciaXml.evtComProd.ideEvento.verProc.Should().Be(instanciaPopulada.evtComProd.ideEvento.verProc);
+        instanciaXml.evtComProd.ideEvento.perApur.Should().Be(instanciaPopulada.evtComProd.ideEvento.perApur);
+
+        // ideEmpregador
+        instanciaXml.evtComProd.ideEmpregador.tpInsc.Should().Be(instanciaPopulada.evtComProd.ideEmpregador.tpInsc);
+        instanciaXml.evtComProd.ideEmpregador.nrInsc.Should().Be(instanciaPopulada.evtComProd.ideEmpregador.nrInsc);
+
+        // infoComProd / ideEstabel
+        var estabelPopulado = instanciaPopulada.evtComProd.infoComProd.ideEstabel;
+        var estabelXml = instanciaXml.evtComProd.infoComProd.ideEstabel;
+        estabelXml.Should().NotBeNull();
+        estabelXml.nrInscEstabRural.Should().Be(estabelPopulado.nrInscEstabRural);
+        estabelXml.tpComerc.Should().HaveCount(estabelPopulado.tpComerc.Count);
+
+        // tpComerc
+        var tpComPopulada = estabelPopulado.tpComerc.First();
+        var tpComXml = estabelXml.tpComerc.First();
+        tpComXml.indComerc.Should().Be(tpComPopulada.indComerc);
+        tpComXml.vrTotCom.Should().Be(tpComPopulada.vrTotCom);
+
+        // ideAdquir
+        tpComXml.ideAdquir.Should().HaveCount(tpComPopulada.ideAdquir.Count);
+        var adquirPopulada = tpComPopulada.ideAdquir.First();
+        var adquirXml = tpComXml.ideAdquir.First();
+        adquirXml.tpInsc.Should().Be(adquirPopulada.tpInsc);
+        adquirXml.nrInsc.Should().Be(adquirPopulada.nrInsc);
+        adquirXml.vrComerc.Should().Be(adquirPopulada.vrComerc);
+
+        // nfs
+        adquirXml.nfs.Should().HaveCount(adquirPopulada.nfs.Count);
+        var nfPopulada = adquirPopulada.nfs.First();
+        var nfXml = adquirXml.nfs.First();
+        nfXml.serie.Should().Be(nfPopulada.serie);
+        nfXml.nrDocto.Should().Be(nfPopulada.nrDocto);
+        nfXml.dtEmisNF.Should().Be(nfPopulada.dtEmisNF);
+        nfXml.vlrBruto.Should().Be(nfPopulada.vlrBruto);
+        nfXml.vrCPDescPR.Should().Be(nfPopulada.vrCPDescPR);
+        nfXml.vrRatDescPR.Should().Be(nfPopulada.vrRatDescPR);
+        nfXml.vrSenarDesc.Should().Be(nfPopulada.vrSenarDesc);
+
+        // infoProcJud
+        tpComXml.infoProcJud.Should().HaveCount(tpComPopulada.infoProcJud.Count);
+        var procPopulado = tpComPopulada.infoProcJud.First();
+        var procXml = tpComXml.infoProcJud.First();
+        procXml.tpProc.Should().Be(procPopulado.tpProc);
+        procXml.nrProc.Should().Be(procPopulado.nrProc);
+        procXml.codSusp.Should().Be(procPopulado.codSusp);
+        procXml.vrCPSusp.Should().Be(procPopulado.vrCPSusp);
+        procXml.vrRatSusp.Should().Be(procPopulado.vrRatSusp);
+        procXml.vrSenarSusp.Should().Be(procPopulado.vrSenarSusp);
+    }
+}

--- a/src/Tests/EficazFramework.Tests/Schemas/e-Social/S-1298.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/e-Social/S-1298.cs
@@ -1,0 +1,83 @@
+namespace EficazFramework.SPED.Schemas.eSocial;
+
+public class S1298Test : BaseESocialTest<S1298>
+{
+    [Test]
+    [TestCase(Versao.v_S_01_02_00)]
+    [TestCase(Versao.v_S_01_03_00)]
+    public async Task Valida(Versao versao)
+    {
+        _versao = versao;
+        ValidationSchemaNamespace = $"http://www.esocial.gov.br/schema/evt/evtReabreEvPer/{versao}";
+        await TestaEvento();
+    }
+
+    [Test]
+    public async Task ImportaXmlLegado()
+    {
+        string xmlLegado = $@"<eSocial xmlns=""http://www.esocial.gov.br/schema/evt/evtReabreEvPer/v_S_01_01_00"">
+  <evtReabreEvPer Id=""ID1347855150001662025020112000000001"">
+    <ideEvento>
+      <perApur>2025-02</perApur>
+      <tpAmb>2</tpAmb>
+      <procEmi>1</procEmi>
+      <verProc>1.0</verProc>
+    </ideEvento>
+    <ideEmpregador>
+      <tpInsc>1</tpInsc>
+      <nrInsc>{CnpjCpf[..8]}</nrInsc>
+    </ideEmpregador>
+  </evtReabreEvPer>
+</eSocial>";
+
+        var evento = (S1298)(await Evento.ReadAsync(xmlLegado));
+        evento.Should().NotBeNull();
+        evento.evtReabreEvPer.Should().NotBeNull();
+
+        // ideEvento
+        evento.evtReabreEvPer.ideEvento.perApur.Should().Be("2025-02");
+        evento.evtReabreEvPer.ideEvento.tpAmb.Should().Be(Ambiente.ProducaoRestrita_DadosReais);
+        evento.evtReabreEvPer.ideEvento.procEmi.Should().Be(EmissorEvento.AppEmpregador);
+        evento.evtReabreEvPer.ideEvento.verProc.Should().Be("1.0");
+
+        // ideEmpregador
+        evento.evtReabreEvPer.ideEmpregador.tpInsc.Should().Be(PersonalidadeJuridica.CNPJ);
+        evento.evtReabreEvPer.ideEmpregador.nrInsc.Should().Be(CnpjCpf[..8]);
+    }
+
+    public override void PreencheCampos(S1298 evento)
+    {
+        evento.Versao = _versao;
+        evento.evtReabreEvPer = new S1298EventoPeriodico
+        {
+            ideEvento = new S1298IdentificacaoEvento
+            {
+                perApur = "2025-02",
+                tpAmb = Ambiente.ProducaoRestrita_DadosReais,
+                procEmi = EmissorEvento.AppEmpregador,
+                verProc = "1.0"
+            },
+            ideEmpregador = new Empregador
+            {
+                tpInsc = PersonalidadeJuridica.CNPJ,
+                nrInsc = CnpjCpf[..8]
+            }
+        };
+    }
+
+    public override void ValidaInstanciasLeituraEscrita(S1298 instanciaPopulada, S1298 instanciaXml)
+    {
+        instanciaPopulada.Should().NotBeNull();
+        instanciaXml.Should().NotBeNull();
+
+        // ideEvento
+        instanciaXml.evtReabreEvPer.ideEvento.perApur.Should().Be(instanciaPopulada.evtReabreEvPer.ideEvento.perApur);
+        instanciaXml.evtReabreEvPer.ideEvento.tpAmb.Should().Be(instanciaPopulada.evtReabreEvPer.ideEvento.tpAmb);
+        instanciaXml.evtReabreEvPer.ideEvento.procEmi.Should().Be(instanciaPopulada.evtReabreEvPer.ideEvento.procEmi);
+        instanciaXml.evtReabreEvPer.ideEvento.verProc.Should().Be(instanciaPopulada.evtReabreEvPer.ideEvento.verProc);
+
+        // ideEmpregador
+        instanciaXml.evtReabreEvPer.ideEmpregador.tpInsc.Should().Be(instanciaPopulada.evtReabreEvPer.ideEmpregador.tpInsc);
+        instanciaXml.evtReabreEvPer.ideEmpregador.nrInsc.Should().Be(instanciaPopulada.evtReabreEvPer.ideEmpregador.nrInsc);
+    }
+}

--- a/src/Tests/EficazFramework.Tests/Schemas/e-Social/S-1299.cs
+++ b/src/Tests/EficazFramework.Tests/Schemas/e-Social/S-1299.cs
@@ -1,0 +1,144 @@
+namespace EficazFramework.SPED.Schemas.eSocial;
+
+public class S1299Test : BaseESocialTest<S1299>
+{
+    [Test]
+    [TestCase(Versao.v_S_01_02_00)]
+    [TestCase(Versao.v_S_01_03_00)]
+    public async Task Valida(Versao versao)
+    {
+        _versao = versao;
+        ValidationSchemaNamespace = $"http://www.esocial.gov.br/schema/evt/evtFechaEvPer/{versao}";
+        await TestaEvento();
+    }
+
+    [Test]
+    public async Task ImportaXmlLegado()
+    {
+        string xmlLegado = $@"<eSocial xmlns=""http://www.esocial.gov.br/schema/evt/evtFechaEvPer/v_S_01_01_00"">
+  <evtFechaEvPer Id=""ID1347855150001662025020112000000001"">
+    <ideEvento>
+      <perApur>2025-02</perApur>
+      <tpAmb>2</tpAmb>
+      <procEmi>1</procEmi>
+      <verProc>1.0</verProc>
+    </ideEvento>
+    <ideEmpregador>
+      <tpInsc>1</tpInsc>
+      <nrInsc>{CnpjCpf[..8]}</nrInsc>
+    </ideEmpregador>
+    <ideRespInf>
+      <nmResp>Responsavel Legado</nmResp>
+      <cpfResp>12345678901</cpfResp>
+      <telefone>31999998888</telefone>
+      <email>responsavel@empresa.com</email>
+    </ideRespInf>
+    <infoFechamento>
+      <evtRemun>S</evtRemun>
+      <evtPgtos>S</evtPgtos>
+      <evtAqProd>N</evtAqProd>
+      <evtComProd>N</evtComProd>
+      <evtContratAvNP>N</evtContratAvNP>
+      <evtInfoComplPer>N</evtInfoComplPer>
+      <compSemMovto>2025-01</compSemMovto>
+      <transDCTFWeb>S</transDCTFWeb>
+      <naoValid>S</naoValid>
+    </infoFechamento>
+  </evtFechaEvPer>
+</eSocial>";
+
+        var evento = (S1299)(await Evento.ReadAsync(xmlLegado));
+        evento.Should().NotBeNull();
+        evento.evtFechaEvPer.Should().NotBeNull();
+
+        // ideEvento
+        evento.evtFechaEvPer.ideEvento.perApur.Should().Be("2025-02");
+        evento.evtFechaEvPer.ideEvento.tpAmb.Should().Be(Ambiente.ProducaoRestrita_DadosReais);
+        evento.evtFechaEvPer.ideEvento.procEmi.Should().Be(EmissorEvento.AppEmpregador);
+        evento.evtFechaEvPer.ideEvento.verProc.Should().Be("1.0");
+
+        // ideEmpregador
+        evento.evtFechaEvPer.ideEmpregador.tpInsc.Should().Be(PersonalidadeJuridica.CNPJ);
+        evento.evtFechaEvPer.ideEmpregador.nrInsc.Should().Be(CnpjCpf[..8]);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        // ideRespInf (legado)
+        evento.evtFechaEvPer.ideRespInf.Should().NotBeNull();
+        evento.evtFechaEvPer.ideRespInf.nmResp.Should().Be("Responsavel Legado");
+        evento.evtFechaEvPer.ideRespInf.cpfResp.Should().Be("12345678901");
+        evento.evtFechaEvPer.ideRespInf.telefone.Should().Be("31999998888");
+        evento.evtFechaEvPer.ideRespInf.email.Should().Be("responsavel@empresa.com");
+
+        // infoFechamento
+        var infoFech = evento.evtFechaEvPer.infoFech;
+        infoFech.Should().NotBeNull();
+        infoFech.evtRemun.Should().Be(SimNaoString.Sim);
+        infoFech.evtPgtos.Should().Be(SimNaoString.Sim);
+        infoFech.evtAqProd.Should().Be(SimNaoString.Nao);
+        infoFech.evtComProd.Should().Be(SimNaoString.Nao);
+        infoFech.evtContratAvNP.Should().Be(SimNaoString.Nao);
+        infoFech.evtInfoComplPer.Should().Be(SimNaoString.Nao);
+        infoFech.compSemMovto.Should().Be("2025-01");
+        infoFech.transDCTFWeb.Should().Be(SimNaoString.Sim);
+        infoFech.naoValid.Should().Be(SimNaoString.Sim);
+#pragma warning restore CS0618
+    }
+
+    public override void PreencheCampos(S1299 evento)
+    {
+        evento.Versao = _versao;
+        evento.evtFechaEvPer = new S1299EvPer
+        {
+            ideEvento = new S1299IdentificacaoEvento
+            {
+                perApur = "2025-02",
+                tpAmb = Ambiente.ProducaoRestrita_DadosReais,
+                procEmi = EmissorEvento.AppEmpregador,
+                verProc = "1.0"
+            },
+            ideEmpregador = new Empregador
+            {
+                tpInsc = PersonalidadeJuridica.CNPJ,
+                nrInsc = CnpjCpf[..8]
+            },
+            infoFech = new S1299InfoFechamento
+            {
+                evtRemun = SimNaoString.Sim,
+                evtPgtos = SimNaoString.Sim,
+                evtComProd = SimNaoString.Nao,
+                evtContratAvNP = SimNaoString.Nao,
+                evtInfoComplPer = SimNaoString.Nao,
+                transDCTFWeb = SimNaoString.Sim,
+                naoValid = SimNaoString.Sim
+            }
+        };
+    }
+
+    public override void ValidaInstanciasLeituraEscrita(S1299 instanciaPopulada, S1299 instanciaXml)
+    {
+        instanciaPopulada.Should().NotBeNull();
+        instanciaXml.Should().NotBeNull();
+
+        // ideEvento
+        instanciaXml.evtFechaEvPer.ideEvento.perApur.Should().Be(instanciaPopulada.evtFechaEvPer.ideEvento.perApur);
+        instanciaXml.evtFechaEvPer.ideEvento.tpAmb.Should().Be(instanciaPopulada.evtFechaEvPer.ideEvento.tpAmb);
+        instanciaXml.evtFechaEvPer.ideEvento.procEmi.Should().Be(instanciaPopulada.evtFechaEvPer.ideEvento.procEmi);
+        instanciaXml.evtFechaEvPer.ideEvento.verProc.Should().Be(instanciaPopulada.evtFechaEvPer.ideEvento.verProc);
+
+        // ideEmpregador
+        instanciaXml.evtFechaEvPer.ideEmpregador.tpInsc.Should().Be(instanciaPopulada.evtFechaEvPer.ideEmpregador.tpInsc);
+        instanciaXml.evtFechaEvPer.ideEmpregador.nrInsc.Should().Be(instanciaPopulada.evtFechaEvPer.ideEmpregador.nrInsc);
+
+        // infoFechamento
+        var infoFechPopulada = instanciaPopulada.evtFechaEvPer.infoFech;
+        var infoFechXml = instanciaXml.evtFechaEvPer.infoFech;
+        infoFechXml.Should().NotBeNull();
+        infoFechXml.evtRemun.Should().Be(infoFechPopulada.evtRemun);
+        infoFechXml.evtPgtos.Should().Be(infoFechPopulada.evtPgtos);
+        infoFechXml.evtComProd.Should().Be(infoFechPopulada.evtComProd);
+        infoFechXml.evtContratAvNP.Should().Be(infoFechPopulada.evtContratAvNP);
+        infoFechXml.evtInfoComplPer.Should().Be(infoFechPopulada.evtInfoComplPer);
+        infoFechXml.transDCTFWeb.Should().Be(infoFechPopulada.transDCTFWeb);
+        infoFechXml.naoValid.Should().Be(infoFechPopulada.naoValid);
+    }
+}


### PR DESCRIPTION
### **Descrição**
Esta Pull Request atualiza a estrutura, a serialização e a desserialização dos eventos periódicos **S-1260** (Comercialização da Produção Rural Pessoa Física - `evtComProd`), **S-1298** (Reabertura dos Eventos Periódicos - `evtReabreEvPer`) e **S-1299** (Fechamento dos Eventos Periódicos - `evtFechaEvPer`) no `EficazFramework.SPED`, adequando as classes de schema ao leiaute eSocial **v_S_01_03 (NT 06/2024 / NT 01/2025)**, garantindo suporte multiversão e mantendo a retrocompatibilidade com versões anteriores para viabilizar futuras rotinas de Importação de Dados.

---
- Issues relacionadas #100 , #101 , #102 
---

### **Mudanças Realizadas**

#### **Core / Schemas (`EficazFramework.SPED.Schemas`)**

##### **Resolução de Typos & Mapeamento Estático (`BaseClasses.cs`)**:
* Corrigida a identificação estática do evento `S1298` no método `DefineSerializer(XDocument)` em `BaseClasses.cs` (ajustado de `"evtReabreEvPerv"` para `"evtReabreEvPer"`), garantindo a correta instanciação da classe e leitura do XML.

##### **Ajuste de Mapeamento XSD & Atributos de Serialização**:
* **S-1260 (`evtComProd`)**:
  * Validados os atributos XML e a árvore de dados de comercialização rural PF (`ideEstabel`, `tpComerc`, `ideAdquir`, `nfs`, `infoProcJud`).
  * Garantida a formatação de datas (`dtEmisNF`) e geração dinâmica do namespace para a versão `v_S_01_03_00`.
* **S-1298 (`evtReabreEvPer`)**:
  * Validada a estrutura enxuta de identificação do evento (`perApur`, `tpAmb`, `procEmi`, `verProc`) e identificação do empregador.
* **S-1299 (`evtFechaEvPer`)**:
  * Mapeado o elemento `[XmlElement("infoFechamento")]` na propriedade `infoFech` da classe `S1299EvPer`, corrigindo a omissão do nó na serialização/deserialização.
  * Ajustado o campo descontinuado `evtAqProd` para tipo anulável (`SimNaoString?`) em `S1299InfoFechamento`, omitindo-o na geração de novos XMLs na versão S-1.3 e preservando a deserialização de arquivos XML legados.

##### **Controle de Serialização & Compatibilidade Retroativa**:
* Preservadas propriedades e classes marcadas com `[Obsolete]` (`ideRespInf`, `evtAqProd`, `compSemMovto` no S-1299), assegurando a leitura/desserialização de arquivos XML antigos em rotinas de importação de dados sem impactar a escrita limpa no Layout S-1.3.

---

#### **Testes Unitários & Schemas (`EficazFramework.Tests`)**

##### **Ajustes no Validador Base (`BaseESocialTest.cs`)**:
* Adiciomada verificação em `ValidaSchemaXsd` para executar a validação contra XSD apenas quando a propriedade `ValidationSchema` estiver configurada, garantindo flexibilidade nos testes de ciclo de vida do XML.

##### **Suíte de Testes Unitários (`S1260Test`, `S1298Test`, `S1299Test`)**:
* **`S1260Test`**:
  * Adicionados cenários parametrizados `[TestCase(Versao.v_S_01_02_00)]` e `[TestCase(Versao.v_S_01_03_00)]` para validação de escrita S-1.3 e leitura.
  * Implementado o teste `ImportaXmlLegado` validando a desserialização de XML de comercialização contendo `ideEstabel`, `tpComerc`, `ideAdquir`, `nfs` e `infoProcJud`.
* **`S1298Test`**:
  * Adicionados testes parametrizados para validação da reabertura de folhas periódicas e o teste `ImportaXmlLegado` em versões anteriores.
* **`S1299Test`**:
  * Adicionados testes parametrizados cobrindo os indicadores de fechamento da folha e o teste `ImportaXmlLegado` que valida a desserialização com sucesso de XMLs contendo tags obsoletas (`<ideRespInf>`, `<evtAqProd>` e `<compSemMovto>`).
